### PR TITLE
Support Auto-Farms

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -30,6 +30,7 @@ interface FilterBarProps {
   filterOptions: FilterOptions;
   onFilterChange: (filters: FilterOptions) => void;
   className?: string;
+  isAutoFarm?: boolean;
 }
 
 const CHAINS = [
@@ -41,7 +42,7 @@ const CHAINS = [
   { id: 8453, name: 'Base' },
 ];
 
-const FilterBar = ({ filterOptions, onFilterChange, className }: FilterBarProps) => {
+const FilterBar = ({ filterOptions, onFilterChange, className, isAutoFarm = false }: FilterBarProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [aprRange, setAprRange] = useState<[number | null, number | null]>([
     filterOptions.minAPR,
@@ -150,44 +151,48 @@ const FilterBar = ({ filterOptions, onFilterChange, className }: FilterBarProps)
                   </Select>
                 </div>
 
-                <div className="space-y-2">
-                  <Label className="text-xs font-medium tracking-wide uppercase text-white/60">Principal Token</Label>
-                  <Select
-                    value={filterOptions.principalToken || "none"}
-                    onValueChange={(value) => handleFilterUpdate('principalToken', value === "none" ? null : value)}
-                  >
-                    <SelectTrigger className="w-full bg-white/5 border-white/10 text-white rounded-lg">
-                      <SelectValue placeholder="Any token" />
-                    </SelectTrigger>
-                    <SelectContent className="bg-[#0D0D0D] border-white/10">
-                      <SelectItem value="none">Any token</SelectItem>
-                      <SelectItem value="USDC">USDC</SelectItem>
-                      <SelectItem value="USDT">USDT</SelectItem>
-                      <SelectItem value="DAI">DAI</SelectItem>
-                      <SelectItem value="WETH">WETH</SelectItem>
-                      <SelectItem value="WBTC">WBTC</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
+                {!isAutoFarm && (
+                  <div className="space-y-2">
+                    <Label className="text-xs font-medium tracking-wide uppercase text-white/60">Principal Token</Label>
+                    <Select
+                      value={filterOptions.principalToken || "none"}
+                      onValueChange={(value) => handleFilterUpdate('principalToken', value === "none" ? null : value)}
+                    >
+                      <SelectTrigger className="w-full bg-white/5 border-white/10 text-white rounded-lg">
+                        <SelectValue placeholder="Any token" />
+                      </SelectTrigger>
+                      <SelectContent className="bg-[#0D0D0D] border-white/10">
+                        <SelectItem value="none">Any token</SelectItem>
+                        <SelectItem value="USDC">USDC</SelectItem>
+                        <SelectItem value="USDT">USDT</SelectItem>
+                        <SelectItem value="DAI">DAI</SelectItem>
+                        <SelectItem value="WETH">WETH</SelectItem>
+                        <SelectItem value="WBTC">WBTC</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
 
-                <div className="space-y-2">
-                  <Label className="text-xs font-medium tracking-wide uppercase text-white/60">Risk Level</Label>
-                  <Select
-                    value={filterOptions.riskLevel || "none"}
-                    onValueChange={(value) => handleFilterUpdate('riskLevel', value === "none" ? null : value)}
-                  >
-                    <SelectTrigger className="w-full bg-white/5 border-white/10 text-white rounded-lg">
-                      <SelectValue placeholder="Any risk level" />
-                    </SelectTrigger>
-                    <SelectContent className="bg-[#0D0D0D] border-white/10">
-                      <SelectItem value="none">Any risk level</SelectItem>
-                      <SelectItem value="LOW">Low</SelectItem>
-                      <SelectItem value="MEDIUM">Medium</SelectItem>
-                      <SelectItem value="ELEVATED">Elevated</SelectItem>
-                      <SelectItem value="HIGH">High</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
+                {!isAutoFarm && (
+                  <div className="space-y-2">
+                    <Label className="text-xs font-medium tracking-wide uppercase text-white/60">Risk Level</Label>
+                    <Select
+                      value={filterOptions.riskLevel || "none"}
+                      onValueChange={(value) => handleFilterUpdate('riskLevel', value === "none" ? null : value)}
+                    >
+                      <SelectTrigger className="w-full bg-white/5 border-white/10 text-white rounded-lg">
+                        <SelectValue placeholder="Any risk level" />
+                      </SelectTrigger>
+                      <SelectContent className="bg-[#0D0D0D] border-white/10">
+                        <SelectItem value="none">Any risk level</SelectItem>
+                        <SelectItem value="LOW">Low</SelectItem>
+                        <SelectItem value="MEDIUM">Medium</SelectItem>
+                        <SelectItem value="ELEVATED">Elevated</SelectItem>
+                        <SelectItem value="HIGH">High</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
 
                 <div className="space-y-2">
                   <Label className="text-xs font-medium tracking-wide uppercase text-white/60">
@@ -224,22 +229,24 @@ const FilterBar = ({ filterOptions, onFilterChange, className }: FilterBarProps)
                   </Select>
                 </div>
 
-                <div className="space-y-2">
-                  <Label className="text-xs font-medium tracking-wide uppercase text-white/60">Strategy Type</Label>
-                  <Select
-                    value={filterOptions.rangeStrategy || "none"}
-                    onValueChange={(value) => handleFilterUpdate('rangeStrategy', value === "none" ? null : value)}
-                  >
-                    <SelectTrigger className="w-full bg-white/5 border-white/10 text-white rounded-lg">
-                      <SelectValue placeholder="Any strategy" />
-                    </SelectTrigger>
-                    <SelectContent className="bg-[#0D0D0D] border-white/10">
-                      <SelectItem value="none">Any strategy</SelectItem>
-                      <SelectItem value="WIDE_RANGE">Wide Range</SelectItem>
-                      <SelectItem value="NARROW_RANGE">Narrow Range</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
+                {!isAutoFarm && (
+                  <div className="space-y-2">
+                    <Label className="text-xs font-medium tracking-wide uppercase text-white/60">Strategy Type</Label>
+                    <Select
+                      value={filterOptions.rangeStrategy || "none"}
+                      onValueChange={(value) => handleFilterUpdate('rangeStrategy', value === "none" ? null : value)}
+                    >
+                      <SelectTrigger className="w-full bg-white/5 border-white/10 text-white rounded-lg">
+                        <SelectValue placeholder="Any strategy" />
+                      </SelectTrigger>
+                      <SelectContent className="bg-[#0D0D0D] border-white/10">
+                        <SelectItem value="none">Any strategy</SelectItem>
+                        <SelectItem value="WIDE_RANGE">Wide Range</SelectItem>
+                        <SelectItem value="NARROW_RANGE">Narrow Range</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
 
                 <div className="flex items-center justify-between">
                   <Label htmlFor="allow-deposit" className="text-xs font-medium tracking-wide uppercase text-white/60">
@@ -278,7 +285,7 @@ const FilterBar = ({ filterOptions, onFilterChange, className }: FilterBarProps)
               />
             </div>
           )}
-          {filterOptions.principalToken && (
+          {!isAutoFarm && filterOptions.principalToken && (
             <div className="bg-white/5 rounded-full px-3 py-1 text-xs flex items-center gap-1 text-white/90">
               Token: {filterOptions.principalToken}
               <X 
@@ -287,7 +294,7 @@ const FilterBar = ({ filterOptions, onFilterChange, className }: FilterBarProps)
               />
             </div>
           )}
-          {filterOptions.riskLevel && (
+          {!isAutoFarm && filterOptions.riskLevel && (
             <div className="bg-white/5 rounded-full px-3 py-1 text-xs flex items-center gap-1 text-white/90">
               Risk: {filterOptions.riskLevel.toLowerCase()}
               <X 
@@ -314,7 +321,7 @@ const FilterBar = ({ filterOptions, onFilterChange, className }: FilterBarProps)
               />
             </div>
           )}
-          {filterOptions.rangeStrategy && (
+          {!isAutoFarm && filterOptions.rangeStrategy && (
             <div className="bg-white/5 rounded-full px-3 py-1 text-xs flex items-center gap-1 text-white/90">
               Strategy: {filterOptions.rangeStrategy.includes('WIDE') ? 'Wide' : 'Narrow'}
               <X 

--- a/src/components/OwnerMetrics.tsx
+++ b/src/components/OwnerMetrics.tsx
@@ -11,9 +11,10 @@ interface OwnerMetricsProps {
   metrics: BuilderMetrics;
   rank?: number;
   vaults?: Vault[];
+  isAutoFarm?: boolean;
 }
 
-const OwnerMetrics = ({ metrics, rank, vaults = [] }: OwnerMetricsProps) => {
+const OwnerMetrics = ({ metrics, rank, vaults = [], isAutoFarm = false }: OwnerMetricsProps) => {
   const { toast } = useToast();
   
   const getExpertiseTag = () => {
@@ -75,7 +76,8 @@ const OwnerMetrics = ({ metrics, rank, vaults = [] }: OwnerMetricsProps) => {
   };
 
   const handleVaultsClick = () => {
-    window.open(`https://defi.krystal.app/account/${metrics.owner}/positions?tab=Vaults#owned_vaults`, '_blank');
+    const hash = isAutoFarm ? '#auto_farm_vault' : '#owned_vault';
+    window.open(`https://defi.krystal.app/account/${metrics.owner}/positions${hash}`, '_blank');
   };
 
   const getAvatarFallback = () => {
@@ -132,14 +134,18 @@ const OwnerMetrics = ({ metrics, rank, vaults = [] }: OwnerMetricsProps) => {
                   )}
                 </div>
                 <div className="text-sm text-white/60 flex items-center gap-2">
-                  <Users className="w-4 h-4" />
-                  {metrics.totalUsers} users
-                  <span>•</span>
+                  {!isAutoFarm && (
+                    <>
+                      <Users className="w-4 h-4" />
+                      {metrics.totalUsers} users
+                      <span>•</span>
+                    </>
+                  )}
                   <div 
                     onClick={handleVaultsClick}
                     className="flex items-center gap-1 group cursor-pointer rounded-full px-3 py-1 bg-white/5 hover:bg-white/10 transition-colors"
                   >
-                    {metrics.totalVaults} vaults
+                    {metrics.totalVaults} {isAutoFarm ? 'auto-farms' : 'vaults'}
                     <ExternalLink className="w-3.5 h-3.5 opacity-60 group-hover:opacity-100 transition-opacity" />
                   </div>
                 </div>
@@ -175,13 +181,15 @@ const OwnerMetrics = ({ metrics, rank, vaults = [] }: OwnerMetricsProps) => {
         </div>
       </div>
 
-      <MetricsDistributionCharts
-        riskProfile={metrics.riskProfile}
-        rangeStrategy={metrics.rangeStrategy}
-        tvlStrategyType={metrics.tvlStrategyType}
-        totalVaults={metrics.totalVaults}
-        vaults={vaults}
-      />
+      {!isAutoFarm && (
+        <MetricsDistributionCharts
+          riskProfile={metrics.riskProfile}
+          rangeStrategy={metrics.rangeStrategy}
+          tvlStrategyType={metrics.tvlStrategyType}
+          totalVaults={metrics.totalVaults}
+          vaults={vaults}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/VaultCard.tsx
+++ b/src/components/VaultCard.tsx
@@ -23,9 +23,10 @@ interface VaultCardProps {
   vault: Vault;
   onClick: (vault: Vault) => void;
   onJoinClick: (e: React.MouseEvent) => void;
+  isAutoFarm?: boolean;
 }
 
-const VaultCard = ({ vault, onClick, onJoinClick }: VaultCardProps) => {
+const VaultCard = ({ vault, onClick, onJoinClick, isAutoFarm = false }: VaultCardProps) => {
   const vaultUrl = `https://defi.krystal.app/vaults/${vault.chainId}/${vault.vaultAddress}`;
 
   return (
@@ -41,11 +42,11 @@ const VaultCard = ({ vault, onClick, onJoinClick }: VaultCardProps) => {
             <ChainBadge chainName={vault.chainName} chainLogo={vault.chainLogo} className="text-white/60" />
             <span className="text-xs font-medium text-white/60 flex items-center gap-1">
               <Clock className="w-3.5 h-3.5" />
-              {calculateDaysAgo(vault.ageInSeconds)}
+              {calculateDaysAgo(vault.ageInSecond)}
             </span>
           </div>
         </div>
-        <TokenIcon token={vault.principalToken} showSymbol={true} />
+        {!isAutoFarm && <TokenIcon token={vault.principalToken} showSymbol={true} />}
       </div>
 
       {/* Metrics Grid */}
@@ -80,11 +81,26 @@ const VaultCard = ({ vault, onClick, onJoinClick }: VaultCardProps) => {
         </div>
       </div>
 
+      {/* Daily Yield for Auto-Farms */}
+      {isAutoFarm && (
+        <div className="rounded-xl bg-white/5 px-3 py-2">
+          <div className="text-xs font-medium text-white/50 mb-1">Daily Yield</div>
+          <div className="text-sm font-semibold text-white">
+            {formatNumber(vault.earning24h || 0)}
+          </div>
+          <div className="text-xs text-[#999]">
+            ~{vault.tvl > 0 ? ((vault.earning24h || 0) / vault.tvl * 100).toFixed(3) : '0.000'}%
+          </div>
+        </div>
+      )}
+
       {/* Risk & Strategy Tags */}
-      <div className="flex flex-wrap gap-2">
-        <RiskBadge risk={vault.riskScore} className="text-xs font-medium px-3 py-[2px]" />
-        <StrategyBadge strategy={vault.rangeStrategyType} className="text-xs font-medium px-3 py-[2px]" />
-      </div>
+      {!isAutoFarm && (
+        <div className="flex flex-wrap gap-2">
+          <RiskBadge risk={vault.riskScore} className="text-xs font-medium px-3 py-[2px]" />
+          <StrategyBadge strategy={vault.rangeStrategyType} className="text-xs font-medium px-3 py-[2px]" />
+        </div>
+      )}
 
       {/* Owner & Users */}
       <div className="space-y-1">
@@ -98,18 +114,20 @@ const VaultCard = ({ vault, onClick, onJoinClick }: VaultCardProps) => {
       </div>
 
       {/* Action Button */}
-      <div>
-        <Button 
-          className="w-full rounded-full border border-white/10 px-4 py-1 text-sm font-medium text-white/90 hover:border-white/30 hover:text-white bg-transparent disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={!vault.allowDeposit}
-          onClick={(e) => {
-            e.stopPropagation();
-            window.open(vaultUrl, '_blank');
-          }}
-        >
-          {vault.allowDeposit ? 'Join' : 'Private'}
-        </Button>
-      </div>
+      {!isAutoFarm && (
+        <div>
+          <Button 
+            className="w-full rounded-full border border-white/10 px-4 py-1 text-sm font-medium text-white/90 hover:border-white/30 hover:text-white bg-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={!vault.allowDeposit}
+            onClick={(e) => {
+              e.stopPropagation();
+              window.open(vaultUrl, '_blank');
+            }}
+          >
+            {vault.allowDeposit ? 'Join' : 'Private'}
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/VaultDetailModal.tsx
+++ b/src/components/VaultDetailModal.tsx
@@ -38,7 +38,7 @@ const VaultDetailModal = ({ vault, open, onOpenChange }: VaultDetailModalProps) 
           </div>
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Clock className="w-4 h-4" />
-            {calculateDaysAgo(vault.ageInSeconds)}
+            {calculateDaysAgo(vault.ageInSecond)}
             <Users className="w-4 h-4 ml-2" />
             {vault.totalUser} users
           </div>

--- a/src/components/VaultTable.tsx
+++ b/src/components/VaultTable.tsx
@@ -15,11 +15,12 @@ interface VaultTableProps {
   onVaultClick: (vault: Vault) => void;
   sortOptions: SortOptions;
   onSortChange: (field: SortField) => void;
+  isAutoFarm?: boolean;
 }
 
 const ITEMS_PER_PAGE = 10;
 
-const VaultTable = ({ vaults, onVaultClick, sortOptions, onSortChange }: VaultTableProps) => {
+const VaultTable = ({ vaults, onVaultClick, sortOptions, onSortChange, isAutoFarm = false }: VaultTableProps) => {
   const [currentPage, setCurrentPage] = React.useState(1);
 
   // Reset pagination when vaults data or sort options change
@@ -43,9 +44,13 @@ const VaultTable = ({ vaults, onVaultClick, sortOptions, onSortChange }: VaultTa
         <table className="w-full text-sm">
           <thead className="bg-[#121212]">
             <tr>
-              <th className="w-[200px] px-5 py-3 text-left font-medium text-sm text-white/60">Vault</th>
+              <th className="w-[200px] px-5 py-3 text-left font-medium text-sm text-white/60">
+                {isAutoFarm ? 'Auto-Farm' : 'Vault'}
+              </th>
               <th className="w-[120px] px-5 py-3 text-left font-medium text-sm text-white/60">Chain</th>
-              <th className="w-[120px] px-5 py-3 text-left font-medium text-sm text-white/60">Principal</th>
+              {!isAutoFarm && (
+                <th className="w-[120px] px-5 py-3 text-left font-medium text-sm text-white/60">Principal</th>
+              )}
               <th className="w-[100px] px-5 py-3 text-right font-medium text-sm text-white/60">
                 <SortHeader field={SortField.APR} label="APR" sortOptions={sortOptions} onSortChange={onSortChange} />
               </th>
@@ -58,10 +63,17 @@ const VaultTable = ({ vaults, onVaultClick, sortOptions, onSortChange }: VaultTa
               <th className="w-[120px] px-5 py-3 text-right font-medium text-sm text-white/60">
                 <SortHeader field={SortField.FEES} label="Fees" sortOptions={sortOptions} onSortChange={onSortChange} />
               </th>
-              <th className="w-[120px] px-5 py-3 text-left font-medium text-sm text-white/60">Strategy</th>
-              <th className="w-[100px] px-5 py-3 text-center font-medium text-sm text-white/60">
-                <SortHeader field={SortField.RISK} label="Risk" sortOptions={sortOptions} onSortChange={onSortChange} />
-              </th>
+              {isAutoFarm && (
+                <th className="w-[120px] px-5 py-3 text-right font-medium text-sm text-white/60">
+                  <SortHeader field={SortField.DAILY_YIELD} label="Daily Yield" sortOptions={sortOptions} onSortChange={onSortChange} />
+                </th>
+              )}
+              {!isAutoFarm && (
+                <th className="w-[120px] px-5 py-3 text-left font-medium text-sm text-white/60">Strategy</th>
+              )}
+              {!isAutoFarm && (
+                <th className="w-[100px] px-5 py-3 text-center font-medium text-sm text-white/60">Risk</th>
+              )}
               <th className="w-[140px] px-5 py-3 text-left font-medium text-sm text-white/60">Owner</th>
             </tr>
           </thead>
@@ -70,7 +82,8 @@ const VaultTable = ({ vaults, onVaultClick, sortOptions, onSortChange }: VaultTa
               <VaultTableRow 
                 key={`${vault.chainId}-${vault.vaultAddress}`}
                 vault={vault} 
-                onVaultClick={onVaultClick} 
+                onVaultClick={onVaultClick}
+                isAutoFarm={isAutoFarm}
               />
             ))}
           </tbody>

--- a/src/components/table/VaultTableRow.tsx
+++ b/src/components/table/VaultTableRow.tsx
@@ -15,9 +15,10 @@ import { Vault } from '@/types/vault';
 interface VaultTableRowProps {
   vault: Vault;
   onVaultClick: (vault: Vault) => void;
+  isAutoFarm?: boolean;
 }
 
-const VaultTableRow = ({ vault, onVaultClick }: VaultTableRowProps) => {
+const VaultTableRow = ({ vault, onVaultClick, isAutoFarm = false }: VaultTableRowProps) => {
   const vaultUrl = `https://defi.krystal.app/vaults/${vault.chainId}/${vault.vaultAddress}`;
 
   return (
@@ -33,9 +34,11 @@ const VaultTableRow = ({ vault, onVaultClick }: VaultTableRowProps) => {
       <td className="w-[120px] px-5 py-3">
         <ChainBadge chainName={vault.chainName} chainLogo={vault.chainLogo} />
       </td>
-      <td className="w-[120px] px-5 py-3">
-        <TokenIcon token={vault.principalToken} size="sm" showSymbol={true} />
-      </td>
+      {!isAutoFarm && (
+        <td className="w-[120px] px-5 py-3">
+          <TokenIcon token={vault.principalToken} size="sm" showSymbol={true} />
+        </td>
+      )}
       <td className="w-[100px] px-5 py-3 text-right font-semibold text-base text-white">
         {formatPercentage(vault.apr)}
       </td>
@@ -51,19 +54,31 @@ const VaultTableRow = ({ vault, onVaultClick }: VaultTableRowProps) => {
       <td className="w-[120px] px-5 py-3 text-right font-semibold text-base text-white">
         {formatNumber(vault.feeGenerated)}
       </td>
-      <td className="w-[120px] px-5 py-3">
-        <StrategyBadge 
-          strategy={vault.rangeStrategyType} 
-          className="bg-white/5 text-violet-300" 
-        />
-      </td>
-      <td className="w-[100px] px-5 py-3 text-center">
-        <RiskBadge 
-          risk={vault.riskScore} 
-          className="bg-white/5" 
-          showIcon={false}
-        />
-      </td>
+      {isAutoFarm && (
+        <td className="w-[120px] px-5 py-3 text-right">
+          <div className="font-semibold text-base text-white">{formatNumber(vault.earning24h || 0)}</div>
+          <div className="text-xs text-[#999]">
+            ~{vault.tvl > 0 ? ((vault.earning24h || 0) / vault.tvl * 100).toFixed(3) : '0.000'}%
+          </div>
+        </td>
+      )}
+      {!isAutoFarm && (
+        <td className="w-[120px] px-5 py-3">
+          <StrategyBadge 
+            strategy={vault.rangeStrategyType} 
+            className="bg-white/5 text-violet-300" 
+          />
+        </td>
+      )}
+      {!isAutoFarm && (
+        <td className="w-[100px] px-5 py-3 text-center">
+          <RiskBadge 
+            risk={vault.riskScore} 
+            className="bg-white/5" 
+            showIcon={false}
+          />
+        </td>
+      )}
       <td className="w-[140px] px-5 py-3 font-medium text-white/60">
         {shortenAddress(vault.owner.address)}
       </td>

--- a/src/hooks/useVaultData.ts
+++ b/src/hooks/useVaultData.ts
@@ -108,6 +108,10 @@ export function useFilteredAndSortedVaults(
           valueA = a.totalUser || 0;
           valueB = b.totalUser || 0;
           break;
+        case SortField.DAILY_YIELD:
+          valueA = a.earning24h || 0;
+          valueB = b.earning24h || 0;
+          break;
         default:
           valueA = a.apr || 0;
           valueB = b.apr || 0;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/tabs';
 import { useToast } from '@/hooks/use-toast';
 import { useBuilderMetrics } from '@/hooks/useBuilderData';
-import { fetchVaults } from '@/services/api';
+import { fetchAllVaults } from '@/services/api';
 import { Vault } from '@/types/vault';
 
 import DiscoverVaultsTab from './DiscoverVaultsTab';
@@ -37,7 +37,7 @@ const Index = () => {
     const loadVaults = async () => {
       try {
         setLoading(true);
-        const response = await fetchVaults();
+        const response = await fetchAllVaults();
         setVaults(response.data);
         toast({
           title: "Vaults loaded successfully",

--- a/src/pages/VaultBuildersTab.tsx
+++ b/src/pages/VaultBuildersTab.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useMemo } from 'react';
-import { BuilderMetrics, Vault } from '@/types/vault';
+import React, { useState, useMemo, useEffect } from 'react';
+import { BuilderMetrics, Vault, VaultType } from '@/types/vault';
 import OwnerMetrics from '@/components/OwnerMetrics';
 import { Skeleton } from '@/components/ui/skeleton';
-import { HelpCircle } from 'lucide-react';
+import { HelpCircle, Share2, Zap } from 'lucide-react';
 import { 
   Pagination, 
   PaginationContent, 
@@ -23,11 +23,113 @@ interface VaultBuildersTabProps {
 const BUILDERS_PER_PAGE = 10;
 
 const VaultBuildersTab: React.FC<VaultBuildersTabProps> = ({ buildersMetrics, vaults, loading }) => {
+  const [vaultType, setVaultType] = useState<VaultType>("autofarm");
   const [sortField, setSortField] = useState<'tvl' | 'apr' | 'fees' | 'users'>('tvl');
   const [currentPage, setCurrentPage] = useState(1);
 
+  // Reset sort to TVL if "users" was selected when switching to Auto-Farms
+  useEffect(() => {
+    if (vaultType === 'autofarm' && sortField === 'users') {
+      setSortField('tvl');
+    }
+  }, [vaultType, sortField]);
+
+  // Filter vaults by type
+  const filteredVaults = useMemo(() => {
+    return vaults.filter(vault => {
+      if (vaultType === 'autofarm') {
+        return vault.isAutoFarmVault === true;
+      }
+      return vault.isAutoFarmVault !== true;
+    });
+  }, [vaults, vaultType]);
+
+  // Compute builder metrics from filtered vaults (not from pre-computed buildersMetrics)
+  const filteredBuilders = useMemo(() => {
+    const builderMap = new Map<string, {
+      owner: string;
+      totalVaults: number;
+      totalTVL: number;
+      totalFeeGenerated: number;
+      averageAPR: number;
+      totalUsers: number;
+      ownerInfo: typeof filteredVaults[0]['owner'];
+      riskProfile: { LOW: number; MODERATE: number; HIGH: number; ELEVATED?: number };
+      rangeStrategy: { WIDE_RANGE: number; NARROW_RANGE: number; UNSET: number };
+      tvlStrategyType: { UNSET: number; LOW_TVL: number; MED_TVL: number; HIGH_TVL: number; WHITELISTED_POOLS: number };
+      depositAllowedCount: number;
+      principalTokens: string[];
+    }>();
+
+    filteredVaults.forEach(vault => {
+      const ownerAddress = vault.owner.address;
+      const existing = builderMap.get(ownerAddress);
+
+      if (existing) {
+        existing.totalVaults += 1;
+        existing.totalTVL += vault.tvl || 0;
+        existing.totalFeeGenerated += vault.feeGenerated || 0;
+        existing.averageAPR = (existing.averageAPR * (existing.totalVaults - 1) + (vault.apr || 0)) / existing.totalVaults;
+        existing.totalUsers += vault.totalUser || 0;
+        if (vault.allowDeposit) existing.depositAllowedCount += 1;
+        
+        // Update risk profile
+        const riskKey = vault.riskScore === 'MEDIUM' ? 'MODERATE' : vault.riskScore;
+        if (riskKey in existing.riskProfile) {
+          existing.riskProfile[riskKey as keyof typeof existing.riskProfile] = 
+            (existing.riskProfile[riskKey as keyof typeof existing.riskProfile] || 0) + 1;
+        }
+        
+        // Update range strategy
+        if (vault.rangeStrategyType in existing.rangeStrategy) {
+          existing.rangeStrategy[vault.rangeStrategyType as keyof typeof existing.rangeStrategy] += 1;
+        } else {
+          existing.rangeStrategy.UNSET += 1;
+        }
+        
+        // Add principal token
+        if (vault.principalToken?.symbol && !existing.principalTokens.includes(vault.principalToken.symbol)) {
+          existing.principalTokens.push(vault.principalToken.symbol);
+        }
+      } else {
+        const riskKey = vault.riskScore === 'MEDIUM' ? 'MODERATE' : vault.riskScore;
+        builderMap.set(ownerAddress, {
+          owner: ownerAddress,
+          totalVaults: 1,
+          totalTVL: vault.tvl || 0,
+          totalFeeGenerated: vault.feeGenerated || 0,
+          averageAPR: vault.apr || 0,
+          totalUsers: vault.totalUser || 0,
+          ownerInfo: vault.owner,
+          riskProfile: {
+            LOW: riskKey === 'LOW' ? 1 : 0,
+            MODERATE: riskKey === 'MODERATE' ? 1 : 0,
+            HIGH: riskKey === 'HIGH' ? 1 : 0,
+            ELEVATED: riskKey === 'ELEVATED' ? 1 : 0,
+          },
+          rangeStrategy: {
+            WIDE_RANGE: vault.rangeStrategyType === 'WIDE_RANGE' ? 1 : 0,
+            NARROW_RANGE: vault.rangeStrategyType === 'NARROW_RANGE' ? 1 : 0,
+            UNSET: !vault.rangeStrategyType || vault.rangeStrategyType === 'UNSET' ? 1 : 0,
+          },
+          tvlStrategyType: {
+            UNSET: 0,
+            LOW_TVL: 0,
+            MED_TVL: 0,
+            HIGH_TVL: 0,
+            WHITELISTED_POOLS: 0,
+          },
+          depositAllowedCount: vault.allowDeposit ? 1 : 0,
+          principalTokens: vault.principalToken?.symbol ? [vault.principalToken.symbol] : [],
+        });
+      }
+    });
+
+    return Array.from(builderMap.values());
+  }, [filteredVaults]);
+
   const sortedBuilders = useMemo(() => {
-    return [...buildersMetrics].sort((a, b) => {
+    return [...filteredBuilders].sort((a, b) => {
       switch (sortField) {
         case 'tvl': return b.totalTVL - a.totalTVL;
         case 'apr': return b.averageAPR - a.averageAPR;
@@ -36,7 +138,7 @@ const VaultBuildersTab: React.FC<VaultBuildersTabProps> = ({ buildersMetrics, va
         default: return b.totalTVL - a.totalTVL;
       }
     });
-  }, [buildersMetrics, sortField]);
+  }, [filteredBuilders, sortField]);
 
   const paginatedBuilders = useMemo(() => {
     const start = (currentPage - 1) * BUILDERS_PER_PAGE;
@@ -44,10 +146,42 @@ const VaultBuildersTab: React.FC<VaultBuildersTabProps> = ({ buildersMetrics, va
     return sortedBuilders.slice(start, end);
   }, [sortedBuilders, currentPage]);
 
-  const totalPages = Math.ceil(buildersMetrics.length / BUILDERS_PER_PAGE);
+  const totalPages = Math.ceil(filteredBuilders.length / BUILDERS_PER_PAGE);
 
   return (
     <section className="w-full max-w-5xl mx-auto py-8 px-4">
+      {/* Vault Type Toggle */}
+      <div className="flex justify-center mb-8">
+        <div className="inline-flex bg-[#0A0A0A] border border-[#1f1f1f] rounded-xl p-1 gap-1">
+          <button
+            onClick={() => setVaultType("autofarm")}
+            className={`
+              flex items-center gap-2 px-5 py-2.5 rounded-lg font-medium text-sm transition-all
+              ${vaultType === "autofarm"
+                ? "bg-gradient-to-r from-[#22C55E] to-[#16A34A] text-white shadow-lg"
+                : "text-[#999] hover:text-white hover:bg-[#1f1f1f]"
+              }
+            `}
+          >
+            <Zap className="w-4 h-4" />
+            Auto-Farms
+          </button>
+          <button
+            onClick={() => setVaultType("shared")}
+            className={`
+              flex items-center gap-2 px-5 py-2.5 rounded-lg font-medium text-sm transition-all
+              ${vaultType === "shared"
+                ? "bg-gradient-to-r from-[#6366F1] to-[#8B5CF6] text-white shadow-lg"
+                : "text-[#999] hover:text-white hover:bg-[#1f1f1f]"
+              }
+            `}
+          >
+            <Share2 className="w-4 h-4" />
+            Shared Vaults
+          </button>
+        </div>
+      </div>
+
       <div className="flex justify-end gap-2 mb-2">
         <select
           className="px-4 py-2.5 rounded-2xl border border-[#1f1f1f] bg-[rgba(255,255,255,0.02)] text-sm font-medium text-white hover:bg-[rgba(255,255,255,0.05)] transition-colors focus:outline-none focus:ring-1 focus:ring-[rgba(255,255,255,0.1)]"
@@ -57,7 +191,7 @@ const VaultBuildersTab: React.FC<VaultBuildersTabProps> = ({ buildersMetrics, va
           <option value="tvl">Sort by TVL</option>
           <option value="apr">Sort by APR</option>
           <option value="fees">Sort by Fees Generated</option>
-          <option value="users">Sort by Users</option>
+          {vaultType !== 'autofarm' && <option value="users">Sort by Users</option>}
         </select>
       </div>
       
@@ -84,7 +218,8 @@ const VaultBuildersTab: React.FC<VaultBuildersTabProps> = ({ buildersMetrics, va
                 <OwnerMetrics
                   metrics={builder}
                   rank={(currentPage - 1) * BUILDERS_PER_PAGE + index + 1}
-                  vaults={vaults.filter(v => v.owner.address === builder.owner)}
+                  vaults={filteredVaults.filter(v => v.owner.address === builder.owner)}
+                  isAutoFarm={vaultType === 'autofarm'}
                 />
               </div>
             ))}

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -86,7 +86,10 @@ export interface Vault {
   userPerformance: UserPerformance;
   earning24h: number;
   earning30d: number;
+  isAutoFarmVault?: boolean;
 }
+
+export type VaultType = 'shared' | 'autofarm';
 
 export interface VaultResponse {
   data: Vault[];
@@ -159,7 +162,9 @@ export enum SortField {
   APR = 'apr',
   PNL = 'pnl',
   FEE_REBATE = 'feeRebate',
-  OWNER = 'owner'
+  OWNER = 'owner',
+  RISK = 'risk',
+  DAILY_YIELD = 'dailyYield'
 }
 
 export interface SortOptions {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds first-class Auto-Farm support and unifies data fetching for both vault types.
> 
> - **Global toggle:** New Auto-Farm/Shared switch in `DiscoverVaultsTab`, `WeeklyLeaderboard`, and `VaultBuildersTab`; hides the Migrate tab for Auto-Farm
> - **API:** `fetchVaults` accepts `isAutoFarmVault`; new `fetchAllVaults` merges shared and auto-farm data; `Index` now loads via `fetchAllVaults`
> - **Types & sorting:** Add `VaultType`, `Vault.isAutoFarmVault`, and `SortField.DAILY_YIELD`; `useFilteredAndSortedVaults` supports `DAILY_YIELD`
> - **Tables/Cards:** Conditional columns and content for Auto-Farm (rename headers to "Auto-Farm", hide `principal`/`risk`/`strategy`, show `Daily Yield` with %); `VaultTableRow` and `VaultCard` render daily yield and suppress join button in Auto-Farm
> - **Filters/metrics:** `FilterBar` hides principal/risk/strategy when `isAutoFarm`; `OwnerMetrics` suppresses user count and distribution charts in Auto-Farm; builder/user/vault links include appropriate hash
> - **Misc:** Standardize age field to `ageInSecond`; switch outbound links to `defi.krystal.app`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6ef4d38fc9bc6522ff96202ee2eb5cea59cd4e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->