### PR TITLE
Support % sorting daily yield

### DIFF
--- a/src/components/VaultTable.tsx
+++ b/src/components/VaultTable.tsx
@@ -64,8 +64,34 @@ const VaultTable = ({ vaults, onVaultClick, sortOptions, onSortChange, isAutoFar
                 <SortHeader field={SortField.FEES} label="Fees" sortOptions={sortOptions} onSortChange={onSortChange} />
               </th>
               {isAutoFarm && (
-                <th className="w-[120px] px-5 py-3 text-right font-medium text-sm text-white/60">
-                  <SortHeader field={SortField.DAILY_YIELD} label="Daily Yield" sortOptions={sortOptions} onSortChange={onSortChange} />
+                <th className="w-[140px] px-5 py-3 text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <span className={`text-sm font-medium ${sortOptions.field === SortField.DAILY_YIELD || sortOptions.field === SortField.DAILY_YIELD_PCT ? 'text-white' : 'text-white/60'}`}>
+                      Daily Yield
+                    </span>
+                    <div className="flex bg-[#1a1a1a] rounded-md overflow-hidden ml-1">
+                      <button
+                        onClick={() => onSortChange(SortField.DAILY_YIELD)}
+                        className={`px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                          sortOptions.field === SortField.DAILY_YIELD
+                            ? 'bg-white text-black'
+                            : 'text-white/60 hover:text-white'
+                        }`}
+                      >
+                        $
+                      </button>
+                      <button
+                        onClick={() => onSortChange(SortField.DAILY_YIELD_PCT)}
+                        className={`px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                          sortOptions.field === SortField.DAILY_YIELD_PCT
+                            ? 'bg-white text-black'
+                            : 'text-white/60 hover:text-white'
+                        }`}
+                      >
+                        %
+                      </button>
+                    </div>
+                  </div>
                 </th>
               )}
               {!isAutoFarm && (

--- a/src/components/WeeklyLeaderboard.tsx
+++ b/src/components/WeeklyLeaderboard.tsx
@@ -324,7 +324,14 @@ const WeeklyLeaderboard = ({ vaults, loading }: WeeklyLeaderboardProps) => {
         case SortField.VAULTS:
           return (a.vaultCount - b.vaultCount) * multiplier;
         case SortField.DAILY_YIELD:
+          // Sort by absolute dollar amount
           return (a.dailyYield - b.dailyYield) * multiplier;
+        case SortField.DAILY_YIELD_PCT: {
+          // Sort by percentage for better comparison across different TVL sizes
+          const yieldPctA = a.totalTvl > 0 ? a.dailyYield / a.totalTvl : 0;
+          const yieldPctB = b.totalTvl > 0 ? b.dailyYield / b.totalTvl : 0;
+          return (yieldPctA - yieldPctB) * multiplier;
+        }
         default:
           return (a.feesEarned - b.feesEarned) * multiplier;
       }
@@ -562,12 +569,33 @@ const WeeklyLeaderboard = ({ vaults, loading }: WeeklyLeaderboardProps) => {
                     onSortChange={handleSortChange}
                   />
                   {vaultType === 'autofarm' && (
-                    <PerformingHeader
-                      field={SortField.DAILY_YIELD}
-                      label="Daily Yield"
-                      sortOptions={sortOptions}
-                      onSortChange={handleSortChange}
-                    />
+                    <th className="text-right pr-2 py-2 min-w-[120px]">
+                      <div className="flex items-center justify-end gap-1">
+                        <span className="text-xs text-[#999] font-semibold uppercase">Daily Yield</span>
+                        <div className="flex bg-[#1a1a1a] rounded-md overflow-hidden ml-1">
+                          <button
+                            onClick={() => handleSortChange(SortField.DAILY_YIELD)}
+                            className={`px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                              sortOptions.field === SortField.DAILY_YIELD
+                                ? 'bg-white text-black'
+                                : 'text-[#999] hover:text-white'
+                            }`}
+                          >
+                            $
+                          </button>
+                          <button
+                            onClick={() => handleSortChange(SortField.DAILY_YIELD_PCT)}
+                            className={`px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                              sortOptions.field === SortField.DAILY_YIELD_PCT
+                                ? 'bg-white text-black'
+                                : 'text-[#999] hover:text-white'
+                            }`}
+                          >
+                            %
+                          </button>
+                        </div>
+                      </div>
+                    </th>
                   )}
                   {vaultType !== 'autofarm' && (
                     <PerformingHeader
@@ -731,10 +759,34 @@ const WeeklyLeaderboard = ({ vaults, loading }: WeeklyLeaderboardProps) => {
                     <SortHeader field={SortField.FEES} label="Fees" sortOptions={sortOptions} onSortChange={handleSortChange} />
                   </th>
                   {vaultType === 'autofarm' && (
-                    <th
-                      className={`text-right text-xs uppercase w-[120px] pr-4 ${sortOptions.field === SortField.DAILY_YIELD ? 'text-white font-semibold' : 'text-[#999] font-semibold'}`}
-                    >
-                      <SortHeader field={SortField.DAILY_YIELD} label="Daily Yield" sortOptions={sortOptions} onSortChange={handleSortChange} />
+                    <th className="text-right text-xs uppercase w-[140px] pr-4">
+                      <div className="flex items-center justify-end gap-1">
+                        <span className={`${sortOptions.field === SortField.DAILY_YIELD || sortOptions.field === SortField.DAILY_YIELD_PCT ? 'text-white font-semibold' : 'text-[#999] font-semibold'}`}>
+                          Daily Yield
+                        </span>
+                        <div className="flex bg-[#1a1a1a] rounded-md overflow-hidden ml-1">
+                          <button
+                            onClick={() => handleSortChange(SortField.DAILY_YIELD)}
+                            className={`px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                              sortOptions.field === SortField.DAILY_YIELD
+                                ? 'bg-white text-black'
+                                : 'text-[#999] hover:text-white'
+                            }`}
+                          >
+                            $
+                          </button>
+                          <button
+                            onClick={() => handleSortChange(SortField.DAILY_YIELD_PCT)}
+                            className={`px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                              sortOptions.field === SortField.DAILY_YIELD_PCT
+                                ? 'bg-white text-black'
+                                : 'text-[#999] hover:text-white'
+                            }`}
+                          >
+                            %
+                          </button>
+                        </div>
+                      </div>
                     </th>
                   )}
                   <th

--- a/src/hooks/useVaultData.ts
+++ b/src/hooks/useVaultData.ts
@@ -109,8 +109,14 @@ export function useFilteredAndSortedVaults(
           valueB = b.totalUser || 0;
           break;
         case SortField.DAILY_YIELD:
+          // Sort by absolute dollar amount
           valueA = a.earning24h || 0;
           valueB = b.earning24h || 0;
+          break;
+        case SortField.DAILY_YIELD_PCT:
+          // Sort by percentage (earning24h / tvl) for better comparison across different TVL sizes
+          valueA = a.tvl > 0 ? (a.earning24h || 0) / a.tvl : 0;
+          valueB = b.tvl > 0 ? (b.earning24h || 0) / b.tvl : 0;
           break;
         default:
           valueA = a.apr || 0;

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -164,7 +164,8 @@ export enum SortField {
   FEE_REBATE = 'feeRebate',
   OWNER = 'owner',
   RISK = 'risk',
-  DAILY_YIELD = 'dailyYield'
+  DAILY_YIELD = 'dailyYield',
+  DAILY_YIELD_PCT = 'dailyYieldPct'
 }
 
 export interface SortOptions {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces dual-mode Daily Yield sorting (absolute $ vs percentage %) and updates UI and logic accordingly.
> 
> - Adds `DAILY_YIELD_PCT` to `SortField` and implements percentage-based sorting in `useVaultData` and builder aggregation in `WeeklyLeaderboard`
> - Replaces single "Daily Yield" sort headers with a `$`/`%` toggle in `VaultTable` and `WeeklyLeaderboard` (Top Performing and Top Vaults tables), with active state highlighting
> - Keeps dollar sorting via `DAILY_YIELD` while enabling percentage comparison normalized by `TVL`
> - Minor layout tweaks (column widths, classes) to accommodate the new toggle
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfd789f26c444eff9d46c5c02d5c2463abc40e0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->